### PR TITLE
Update eve images to HTTPS

### DIFF
--- a/evepraisal/templates/kinds/default.html
+++ b/evepraisal/templates/kinds/default.html
@@ -20,7 +20,7 @@
       <td>
           <div class="media">
             {% set market_url = "http://eve-central.com/home/quicklook.html?typeid=%s"|format(typeID) %}
-            {% if is_from_igb() %}<a href="#" onclick="CCPEVE.showMarketDetails({{ typeID }})"> {% else %}<a href="{{market_url}}" target="_blank">{% endif %}<img class="pull-left media-object" src="http://image.eveonline.com/Type/{{ typeID }}_32.png" alt="{{ item.typeName }}"></a> &nbsp;<a href="{{market_url}}" target="_blank">{{ name }}</a>
+            {% if is_from_igb() %}<a href="#" onclick="CCPEVE.showMarketDetails({{ typeID }})"> {% else %}<a href="{{market_url}}" target="_blank">{% endif %}<img class="pull-left media-object" src="https://image.eveonline.com/Type/{{ typeID }}_32.png" alt="{{ item.typeName }}"></a> &nbsp;<a href="{{market_url}}" target="_blank">{{ name }}</a>
           </div>
       </td>
       <td style="text-align:right">{{ item.volume|format_volume }}</td>


### PR DESCRIPTION
This changes image urls to use HTTPS instead of plain HTTP.
This is useful e.g. when hosting an evepraisal instance with HTTPS as the images would be "unsafe content" when fetched via HTTP.